### PR TITLE
change allocator from `netty` to `unsafe` to be compatible with Tableau

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'java'
 apply plugin: 'com.diffplug.spotless'
 
 group 'io.tiledb'
-version = '0.0.8-SNAPSHOT'
+version = '0.0.9-SNAPSHOT'
 
 repositories {
     mavenCentral()
@@ -157,7 +157,7 @@ dependencies {
     implementation "jakarta.annotation:jakarta.annotation-api:$jakarta_annotation_version"
     implementation group: 'org.apache.arrow', name: 'arrow-vector', version: '9.0.0'
     implementation group: 'org.apache.arrow', name: 'arrow-compression', version: '9.0.0'
-    implementation group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '9.0.0'
+    implementation group: 'org.apache.arrow', name: 'arrow-memory-unsafe', version: '9.0.0'
     implementation 'io.tiledb:tiledb-java:0.13.6'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation 'org.mockito:mockito-core:3.12.4'

--- a/src/main/java/io/tiledb/cloud/TileDBClient.java
+++ b/src/main/java/io/tiledb/cloud/TileDBClient.java
@@ -28,6 +28,8 @@ public class TileDBClient{
 
     private static final String homeDir = System.getProperty("user.home");
 
+    private static String cloudFilePath;
+
     static Logger logger = Logger.getLogger(TileDBClient.class.getName());
 
     private ApiClient apiClient;
@@ -42,6 +44,14 @@ public class TileDBClient{
         password = "";
         basePath = "https://api.tiledb.com/v1";
         loginInfoIsInJSONFile = true;
+
+        // set path according to OS
+        if (System.getProperty("os.name").toLowerCase().contains("windows")){
+            cloudFilePath = "\\.tiledb\\cloud.json";
+        } else{
+            cloudFilePath = "/.tiledb/cloud.json";
+        }
+
         boolean ok =  false;
         try {
             ok = loadCloudJSONFileFromHome();
@@ -60,7 +70,7 @@ public class TileDBClient{
      * @throws IOException
      */
     private static boolean loadCloudJSONFileFromHome() throws IOException {
-        String fileName = homeDir + "/.tiledb/cloud.json";
+        String fileName = homeDir + cloudFilePath;
 
         File initialFile = new File(fileName);
         InputStream is = Files.newInputStream(initialFile.toPath());
@@ -148,7 +158,7 @@ public class TileDBClient{
         jsonObject.put("host", "https://api.tiledb.com");
         jsonObject.put("verify_ssl", verifyingSsl);
         try {
-            File file = new File(homeDir + "/.tiledb/cloud.json");
+            File file = new File(homeDir + cloudFilePath);
             file.getParentFile().mkdirs(); //create /.tiledb dir if not present
             FileWriter fileWriter = new FileWriter(file);
             fileWriter.write(jsonObject.toString());

--- a/src/main/java/io/tiledb/cloud/TileDBSQL.java
+++ b/src/main/java/io/tiledb/cloud/TileDBSQL.java
@@ -4,6 +4,7 @@ import io.tiledb.cloud.rest_api.ApiException;
 import io.tiledb.cloud.rest_api.api.SqlApi;
 import io.tiledb.cloud.rest_api.model.SQLParameters;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.memory.UnsafeAllocationManager;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -60,7 +61,8 @@ public class TileDBSQL implements AutoCloseable{
             ArrayList<ValueVector> valueVectors = null;
             int readBatchesCount = 0;
 
-            RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+//            RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+            RootAllocator allocator = new RootAllocator(RootAllocator.configBuilder().allocationManagerFactory(UnsafeAllocationManager.FACTORY).build());
             ArrowStreamReader reader = new ArrowStreamReader(new ByteArrayInputStream(bytes), allocator, CommonsCompressionFactory.INSTANCE);
 
             VectorSchemaRoot root = reader.getVectorSchemaRoot();


### PR DESCRIPTION
Changing the arrow allocation manager to bypass an error generated by Tableau:

`java.lang.IllegalAccessError: class io.netty.buffer.UnsafeDirectLittleEndian cannot access its superclass io.netty.buffer.WrappedByteBuf (io.netty.buffer.UnsafeDirectLittleEndian is in unnamed module of loader java.net.FactoryURLClassLoader @b0409eb; `