### PR TITLE
Do not expect ```v1``` when using a custom Host URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'java'
 apply plugin: 'com.diffplug.spotless'
 
 group 'io.tiledb'
-version = '0.3.1-SNAPSHOT'
+version = '0.3.2-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/src/main/java/examples/Examples.java
+++ b/src/main/java/examples/Examples.java
@@ -18,7 +18,7 @@ import static io.tiledb.cloud.TileDBUtils.serializeArgs;
 
 public class Examples
 {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws ApiException {
 
 //      if using cloud for the first time create the client with a Login object to pass your credentials.
         TileDBClient tileDBClient = new TileDBClient(
@@ -27,7 +27,8 @@ public class Examples
                         System.getenv("API_TOKEN"),
                         true,
                         true,
-                        true));
+                        true,
+                        "https://api.tiledb.com"));
 
 //      If the "RememberME" option is set to true in your first login you can access TileDB-Cloud without the need
 //      to pass any credentials from now on. Just create the client as follows:

--- a/src/main/java/io/tiledb/cloud/TileDBLogin.java
+++ b/src/main/java/io/tiledb/cloud/TileDBLogin.java
@@ -58,15 +58,13 @@ public class TileDBLogin {
      */
     public TileDBLogin(String username, String password, String apiKey, boolean verifySSL,
                        boolean rememberMe, boolean overwritePrevious, String host) throws ApiException {
-        if (host.equals("https://api.tiledb.com/v2")){
-            throw new ApiException("https://api.tiledb.com/v2 is not yet supported");
-        }
+
         this.password = password;
         this.username = username;
         this.apiKey = apiKey;
         this.verifySSL = verifySSL;
         this.rememberMe = rememberMe;
-        this.host = host;
+        this.host = host + "/v1";
         this.overwritePrevious = overwritePrevious;
     }
 


### PR DESCRIPTION
The Login object's constructor that had ```host``` as a parameter was expecting a host URL of type ```https://api.tiledb.com/v1```

It is now expecting ```https://api.tiledb.com```. This aligns with the Python API

[sc-48926]