### PR TITLE
`publish.yml`: only create release for tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Create Release
         id: create_release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fast-follow to #39, allowing `publish.yml` to be `workflow_dispatch`'d from any commit, to publish a `-SNAPSHOT` to Sonatype OSS.

e.g. [this GHA](https://github.com/TileDB-Inc/TileDB-Cloud-Java/actions/runs/15300491901/job/43039586358) published a new [1.0.0-SNAPSHOT](https://github.com/TileDB-Inc/TileDB-Cloud-Java/actions/runs/15300491901/job/43039586358) from https://github.com/TileDB-Inc/TileDB-Cloud-Java/commit/f05da76dbcfc075e7e3f717988aff3404c6546ff (#37, with #39 and this PR merged in)